### PR TITLE
wurlitzer 3.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "wurlitzer" %}
-{% set version = "2.1.1" %}
+{% set version = "3.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5a3ea5a13a8aac2d808864087fec87a0518bf7d9776173ab06a6bb4ade9f4d27
+  sha256: 36051ac530ddb461a86b6227c4b09d95f30a1d1043de2b4a592e97ae8a84fcdf
 
 build:
   skip: true  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 36051ac530ddb461a86b6227c4b09d95f30a1d1043de2b4a592e97ae8a84fcdf
 
 build:
-  skip: true  # [win]
+  skip: true  # [win or py<35]
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
 
@@ -22,7 +22,6 @@ requirements:
     - wheel
   run:
     - python
-    - selectors2  # [py==27]
 
 test:
   imports:
@@ -37,7 +36,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'Capture C-level stdout/stderr in Python'
+  summary: Capture C-level stdout/stderr in Python
   dev_url: https://github.com/minrk/wurlitzer
   doc_url: https://github.com/minrk/wurlitzer/blob/main/README.md
 


### PR DESCRIPTION
Update wurlitzer to 3.0.2

Version change: bump version number from 2.1.1 to 3.0.2 (Major version bump!)
Bug Tracker: new open issues https://github.com/minrk/wurlitzer/issues
Upstream license:  License file:  https://github.com/minrk/wurlitzer/blob/master/LICENSE
Upstream Changelog: https://github.com/minrk/wurlitzer/blob/main/CHANGELOG.md
Upstream setup.py:  https://github.com/minrk/wurlitzer/blob/3.0.2/setup.py

The package wurlitzer is mentioned inside the packages:
spyder-kernels | spyder-kernels-0.x | 

Actions:
1. Skip py<35
2. Update run dependencies

Result:
- all-succeeded