### PR TITLE
wurlitzer 3.1.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,35 +1,39 @@
 {% set name = "wurlitzer" %}
-{% set version = "3.0.2" %}
+{% set version = "3.1.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 36051ac530ddb461a86b6227c4b09d95f30a1d1043de2b4a592e97ae8a84fcdf
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: bfb9144ab9f02487d802b9ff89dbd3fa382d08f73e12db8adc4c2fb00cd39bd9
 
 build:
   skip: true  # [win or py<35]
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python
     - pip
     - setuptools
-    - wheel
   run:
     - python
 
 test:
+  source_files:
+    - test.py
   imports:
     - wurlitzer
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v test.py
 
 about:
   home: https://github.com/minrk/wurlitzer
@@ -37,6 +41,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Capture C-level stdout/stderr in Python
+  description: Capture C-level stdout/stderr in Python via os.dup2
   dev_url: https://github.com/minrk/wurlitzer
   doc_url: https://github.com/minrk/wurlitzer/blob/main/README.md
 


### PR DESCRIPTION
wurlitzer 3.1.1 

**Destination channel:** Defaults

### Links

- [PKG-9422]
- dev_url:        https://github.com/minrk/wurlitzer/tree/3.1.1
- conda_forge:    https://github.com/conda-forge/wurlitzer-feedstock
- pypi:           https://pypi.org/project/wurlitzer/3.1.1
- pypi inspector: https://inspector.pypi.io/project/wurlitzer/3.1.1

### Explanation of changes:

- new version number


[PKG-9422]: https://anaconda.atlassian.net/browse/PKG-9422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ